### PR TITLE
Fix: Acesso a índice não definido no array.

### DIFF
--- a/App/Controllers/UrlsController.php
+++ b/App/Controllers/UrlsController.php
@@ -102,7 +102,7 @@ class UrlsController extends Action {
     $abs = "$host$path/$rel";
     $re = array('#(/\.?/)#', '#/(?!\.\.)[^/]+/\.\./#');
     for ($n = 1; $n > 0; $abs = preg_replace($re, '/', $abs, -1, $n)) {
-      
+
     }
 
     $abs = str_replace("../", "", $abs);
@@ -112,11 +112,14 @@ class UrlsController extends Action {
 
   private function perfect_url($u, $b) {
     $bp = parse_url($b);
+    if (!isset($bp['path']))
+      $bp['path'] = '';
+
     if (($bp['path'] != "/" && $bp['path'] != "") || $bp['path'] == '') {
       if ($bp['scheme'] == "") {
-	$scheme = "http";
+        $scheme = "http";
       } else {
-	$scheme = $bp['scheme'];
+        $scheme = $bp['scheme'];
       }
       $b = $scheme . "://" . $bp['host'] . "/";
     }


### PR DESCRIPTION
O commit em questão só evita o warning da chave do array que não existe.
Mas gostaria de comentar que a forma como o crawler foi implementado não resolve o principal objetivo do desafio que é montar um sistema escalável.
No caso, o ideal seria o index.php do crawler ler as URLs que precisam de um "dump" atualizado e distribuir a tarefa para processos filhos, workers totalmente isolados.
Outra coisa que notei foi que a URL referenciada pelo crawler-admin para visualizar o resultado do crawler começava com `/public`, o que fazia o link não funcionar.

Tirando esses pequenos detalhes que tive que corrigir, e mais alguns para rodar o sistema no meu ambiente (host externo no vagrant e não localhost), eu consegui utilizar o sistema.